### PR TITLE
fixes #5698 - skipping matching of the particular bot related regexp …

### DIFF
--- a/Parser/Bot.php
+++ b/Parser/Bot.php
@@ -51,18 +51,16 @@ class Bot extends ParserAbstract
         $result = null;
 
         if ($this->preMatchOverall()) {
-            foreach ($this->getRegexes() as $regex) {
-                $matches = $this->matchUserAgent($regex['regex']);
-
-                if ($matches) {
-                    if ($this->discardDetails) {
-                        $result = true;
+            if ($this->discardDetails) {
+                $result = true;
+            } else {
+                foreach ($this->getRegexes() as $regex) {
+                    $matches = $this->matchUserAgent($regex['regex']);
+                    if ($matches) {
+                        unset($regex['regex']);
+                        $result = $regex;
                         break;
                     }
-
-                    unset($regex['regex']);
-                    $result = $regex;
-                    break;
                 }
             }
         }


### PR DESCRIPTION
…when `discardDetails` enabled for `Bot` parser